### PR TITLE
Fix multiple definitions of several symbols

### DIFF
--- a/src/gtk-gui.h
+++ b/src/gtk-gui.h
@@ -47,7 +47,7 @@
 #define MAX_PAD_HEIGHT 40 
 #define MAX_PAD_WIDTH  70
 
-u_int8_t pointer[MAX_PROTOCOLS];
+extern u_int8_t pointer[MAX_PROTOCOLS];
 
 void gtk_gui(void *);
 void gtk_gui_th_exit(struct term_node *);

--- a/src/gtk-interface.c
+++ b/src/gtk-interface.c
@@ -35,6 +35,8 @@
 #include <gtk/gtk.h>
 
 #include "gtk-interface.h"
+GtkWidget *protocols_tree[MAX_PROTOCOLS + 1];
+GtkListStore *protocols_tree_model[MAX_PROTOCOLS + 1];
 
 #define GLADE_HOOKUP_OBJECT(component,widget,name) \
   g_object_set_data_full (G_OBJECT (component), name, \

--- a/src/gtk-interface.h
+++ b/src/gtk-interface.h
@@ -26,8 +26,8 @@
 #include "gtk-callbacks.h"
 #include "gtk-support.h"
 
-GtkWidget *protocols_tree[MAX_PROTOCOLS + 1];
-GtkListStore *protocols_tree_model[MAX_PROTOCOLS + 1];
+extern GtkWidget *protocols_tree[MAX_PROTOCOLS + 1];
+extern GtkListStore *protocols_tree_model[MAX_PROTOCOLS + 1];
 
 GtkWidget* gtk_i_create_Main (struct gtk_s_helper *);
 GtkWidget* gtk_i_create_opendialog (struct gtk_s_helper *);

--- a/src/interfaces.c
+++ b/src/interfaces.c
@@ -101,7 +101,7 @@
 #endif
 
 #include "interfaces.h"
-
+list_t *interfaces;
 
 
 

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -67,7 +67,7 @@
 
 #define NO_TIMEOUT  0
 
-list_t *interfaces;
+extern list_t *interfaces;
 
 struct interface_data {
        int8_t   up;                  /* is it active? */

--- a/src/ncurses-callbacks.h
+++ b/src/ncurses-callbacks.h
@@ -77,8 +77,8 @@
 #define CAN_RESIZE 1
 #endif
 
-u_int8_t pointer[MAX_PROTOCOLS];
-WINDOW *info_window;
+extern u_int8_t pointer[MAX_PROTOCOLS];
+extern WINDOW *info_window;
 
 void    ncurses_c_refresh_mwindow(u_int8_t, WINDOW *, u_int8_t, struct term_node *);
 void    ncurses_c_refresh_bwindow(u_int8_t, WINDOW *, struct term_node *);

--- a/src/ncurses-interface.c
+++ b/src/ncurses-interface.c
@@ -90,6 +90,8 @@
 #endif
 
 #include "ncurses-interface.h"
+u_int8_t pointer[MAX_PROTOCOLS];
+WINDOW *info_window;
 #include "ncurses-callbacks.h"
 
 

--- a/src/ncurses-interface.h
+++ b/src/ncurses-interface.h
@@ -80,8 +80,8 @@
 #define CAN_RESIZE 1
 #endif
 
-u_int8_t pointer[MAX_PROTOCOLS];
-WINDOW *info_window;
+extern u_int8_t pointer[MAX_PROTOCOLS];
+extern WINDOW *info_window;
 
 int8_t  ncurses_i_init(WINDOW *[], PANEL *[], struct term_node *);
 void    ncurses_i_add_node(void);

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -60,6 +60,7 @@
 #include <ctype.h>
 
 #include "protocols.h"
+struct protocol_def protocols[MAX_PROTOCOLS];
 
 void
 protocol_init(void)

--- a/src/protocols.h
+++ b/src/protocols.h
@@ -207,7 +207,7 @@ struct protocol_def {
        end_t end;
 };
 
-struct protocol_def protocols[MAX_PROTOCOLS];
+extern struct protocol_def protocols[MAX_PROTOCOLS];
 
 void   protocol_init(void);
 int8_t protocol_register(u_int8_t, const char *, const char *, const char *,


### PR DESCRIPTION
Those multiple definitions would prevent the code from linking (Archlinux, GCC 10.2.0, ld 2.36.1)