### PR TITLE
ncurses: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/ncurses-callbacks.c
+++ b/src/ncurses-callbacks.c
@@ -164,7 +164,7 @@ void ncurses_c_refresh_mwindow( u_int8_t mode, WINDOW *mwindow, u_int8_t pointer
    position = 1;
    for (i = 0; i < protocols[mode].nparams; i++) {
       if (params[i].mwindow) {
-         mvwprintw(mwindow, 1, position + offset, params[i].ldesc);
+         mvwprintw(mwindow, 1, position + offset, "%s", params[i].ldesc);
          if (params[i].meaning)
          {
             max_len = parser_get_max_field_length(params[i].meaning);
@@ -177,7 +177,7 @@ void ncurses_c_refresh_mwindow( u_int8_t mode, WINDOW *mwindow, u_int8_t pointer
 
    for (i = 0; i < protocols[mode].extra_nparams; i++) {
       if (extra_params[i].mwindow) {
-         mvwprintw(mwindow, 1, position + offset, extra_params[i].ldesc);
+         mvwprintw(mwindow, 1, position + offset, "%s", extra_params[i].ldesc);
          if (extra_params[i].meaning)
          {
             max_len = parser_get_max_field_length(extra_params[i].meaning);

--- a/src/ncurses-interface.c
+++ b/src/ncurses-interface.c
@@ -1187,14 +1187,14 @@ int8_t ncurses_i_error_window( u_int8_t mode, char *message, ... )
       if (message_s >= max_y - 4) {
          strncpy(m_split, ptr, max_y - 4);
          m_split[max_y-4] = '\0';
-         mvwprintw(my_window, i, 2, m_split);
+         mvwprintw(my_window, i, 2, "%s", m_split);
          message_s -= max_y - 4;
          ptr += max_y - 4;
          /* offset */
       } else {
          strncpy(m_split, ptr, message_s);
          m_split[message_s] = '\0';
-         mvwprintw(my_window, i, 2, m_split);
+         mvwprintw(my_window, i, 2, "%s", m_split);
          message_s = 0;
       }
       i++;
@@ -1247,7 +1247,7 @@ ncurses_i_getstring_window(struct term_node *term, char *status, char *data, u_i
    wattron(my_window, COLOR_PAIR(3));
    box(my_window, 0, 0);
 
-   mvwprintw(my_window, 0, 2, message);
+   mvwprintw(my_window, 0, 2, "%s", message);
 
    mvwprintw(my_window, max_x - 1, 2, " Press Enter to continue ");
    wattroff(my_window, COLOR_PAIR(3));
@@ -1301,13 +1301,13 @@ ncurses_i_getconfirm(struct term_node *term, char *status, char *message, char *
    wattron(my_window, COLOR_PAIR(3));
    box(my_window, 0, 0);
 
-   mvwprintw(my_window, 0, 2, title);
+   mvwprintw(my_window, 0, 2, "%s", title);
 
-   mvwprintw(my_window, max_y - 1, 2, bottom);
+   mvwprintw(my_window, max_y - 1, 2, "%s", bottom);
 
    wattroff(my_window, COLOR_PAIR(3));
 
-   mvwprintw(my_window, max_y - 3, 1, message);
+   mvwprintw(my_window, max_y - 3, 1, "%s", message);
 
    wtimeout(my_window,NCURSES_KEY_TIMEOUT); /* Block for 100 millisecs...*/
 
@@ -1831,7 +1831,7 @@ ncurses_i_attack_get_params(struct attack_param *param, u_int8_t nparams)
 
    mvwprintw(my_window, 0, 2, "Attack parameters");
 
-   mvwprintw(my_window, max_y - 1, 2, bottom);
+   mvwprintw(my_window, max_y - 1, 2, "%s", bottom);
    wattroff(my_window, COLOR_PAIR(3));
 
    wmove(my_window, max_x - 3, 1);


### PR DESCRIPTION
>ncuses-6.3 added printf-style function attributes and now makes it easier to catch cases when user input is used in place of format string when built with CFLAGS=-Werror=format-security.

In yersinia a typical build failure looks like:
```
ncurses-interface.c: In function 'ncurses_i_error_window':
ncurses-interface.c:1190:10: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
 1190 |          mvwprintw(my_window, i, 2, m_split);
      |          ^~~~~~~~~
```

> Let's wrap all the missing places with "%s" format.

Thanks to @trofi for writing https://discourse.nixos.org/t/uncoming-ncurses-6-2-6-3-update/16169 motivating this PR as I'm working on packaging yersinia for NixOS :)