### PR TITLE
Updated pointer variables with static in gtk-gui.h and gtk-interface.h

### DIFF
--- a/src/gtk-gui.h
+++ b/src/gtk-gui.h
@@ -47,7 +47,7 @@
 #define MAX_PAD_HEIGHT 40 
 #define MAX_PAD_WIDTH  70
 
-u_int8_t pointer[MAX_PROTOCOLS];
+static u_int8_t pointer[MAX_PROTOCOLS];
 
 void gtk_gui(void *);
 void gtk_gui_th_exit(struct term_node *);

--- a/src/gtk-interface.h
+++ b/src/gtk-interface.h
@@ -26,8 +26,8 @@
 #include "gtk-callbacks.h"
 #include "gtk-support.h"
 
-GtkWidget *protocols_tree[MAX_PROTOCOLS + 1];
-GtkListStore *protocols_tree_model[MAX_PROTOCOLS + 1];
+static GtkWidget *protocols_tree[MAX_PROTOCOLS + 1];
+static GtkListStore *protocols_tree_model[MAX_PROTOCOLS + 1];
 
 GtkWidget* gtk_i_create_Main (struct gtk_s_helper *);
 GtkWidget* gtk_i_create_opendialog (struct gtk_s_helper *);


### PR DESCRIPTION
Fixed issue #71 by changing header pointers to static in order to avoid make errors with multiple definitions. 