### PR TITLE
Fixing segfault bug on write_log() + (some typo's)

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -1381,7 +1381,9 @@ char **dhcp_get_printable_packet( struct pcap_data *data )
 
         if ( !len && type != LIBNET_DHCP_END )
         {
-            write_log(0, "Error in dhcp_get_printable: len is %d and type is %d\n", len, type);
+            write_log(1,
+                      "Unsupported option of len '%d' and type '%d'\n",
+                      len, type);
             free( buffer );
             return field_values;
         }

--- a/src/dhcp.h
+++ b/src/dhcp.h
@@ -396,7 +396,7 @@ void   dhcp_th_dos_send_release_exit(struct attacks *);
 #define DHCP_ROGUE_DOMAIN     8
 
 static struct attack_param dhcp_rogue_server_params[] = {
-    { NULL, "Server ID",               4, FIELD_IP,  15, NULL },
+    { NULL, "Server IP",               4, FIELD_IP,  15, NULL },
     { NULL, "Start IP",                4, FIELD_IP,  15, NULL },
     { NULL, "End IP",                  4, FIELD_IP,  15, NULL },
     { NULL, "Lease Time (secs)",       4, FIELD_HEX,  8, NULL },
@@ -412,7 +412,7 @@ static struct attack_param dhcp_rogue_server_params[] = {
 #define DHCP_DOS_SEND_RELEASE_END_IP     2 
 
 static struct attack_param dhcp_dos_send_release_params[] = {
-    { NULL, "Server ID",               4, FIELD_IP,  15, NULL },
+    { NULL, "Server IP",               4, FIELD_IP,  15, NULL },
     { NULL, "Start IP",                4, FIELD_IP,  15, NULL },
     { NULL, "End IP",                  4, FIELD_IP,  15, NULL }
 };

--- a/src/yersinia.c
+++ b/src/yersinia.c
@@ -654,6 +654,7 @@ write_log( u_int16_t mode, char *msg, ... )
     if (mode && !tty_tmp->daemonize)
         vfprintf(stdout, msg, ap);
 
+    va_start(ap,msg);
     if ((!mode || (mode == 1)) && (tty_tmp->log_file))
        vfprintf(tty_tmp->log_file, msg,ap);
 


### PR DESCRIPTION
This PR resolves the issue #74 by modifying the `write_log()` function.

Also, it corrects some typos on some DHCP `attack_param` structures (by changing _Server ID_ to _Server IP_)

