### PR TITLE
configure: fix -Wimplicit-function-declaration, -Wimplicit-int

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -79,8 +79,10 @@ AC_DEFUN([AC_LBL_UNALIGNED_ACCESS],
 #       include <sys/types.h>
 #       include <sys/wait.h>
 #       include <stdio.h>
+#       include <stdlib.h>
+#       include <unistd.h>
         unsigned char a[[5]] = { 1, 2, 3, 4, 5 };
-        main() {
+        int main(void) {
         unsigned int i;
         pid_t pid;
         int status;


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration and -Wimplicit-int errors by default. Unfortunately, this can lead to misconfiguration or miscompilation of software as configure tests may then return the wrong result.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2], or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213 [2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Followup to 6414681ae99d6a0f460f827648f114aa3cb2e419.

Signed-off-by: Sam James <sam@gentoo.org>