### PR TITLE
fix help option not exit problem

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -103,7 +103,7 @@ parser_initial(struct term_tty *tty, struct cl_args *cl_args, int argc, char **a
        if (!strcmp(argv[i],"-h") || !strcmp(argv[i],"--help"))
        {
           parser_help();
-          break;
+          return -1;
        }
        else
        if (!strcmp(argv[i],"-V") || !strcmp(argv[i],"--Version"))


### PR DESCRIPTION
## 🩹 Fix: Exit immediately after showing help (`-h` or `--help`)

### 🐛 Problem

When running:

```bash
yersinia -h
```

The program prints help but continues execution, which leads to:

```bash
./yersinia -h cdp
    ۲�۲��                                                                       
   �۰����۲�                                                                     
 ۲�����۰�۲�                                                                     
�����۱��۲������                                                                 
����۱�����۲�����                                                                
����۱������۰�����               Yersinia...                                     
�����۲�������۰��۲��                                                             
۲���۱���������۰���۲��         The Black Death for nowadays networks             
 ������۱���������۰������                                                        
 ��۰���۱�����������۰��۲�             by Slay & tomac                            
  ۲�۲��۱������������۲�����                                                      
     ��۲�۱�������������۰����        http://www.yersinia.net                     
      ۲����۱�������������۲۲            yersinia@yersinia.net                    
       ۲�����۱����������۲���                                                    
         �۲����۱�������۲�۲�                                                     
         �۲�۰������۱�۰����     Prune your MSTP, RSTP, STP trees!!!!             
             ��۰���������۲�                                                     
�

Usage: yersinia [-hVGIDd] [-l logfile] [-c conffile] protocol [protocol_options]
       -V   Program version.
       -h   This help screen.
       -G   Graphical mode (GTK).
       -I   Interactive mode (ncurses).
       -D   Daemon mode.
       -d   Debug.
       -l logfile   Select logfile.
       -c conffile  Select config file.
  protocol   One of the following: cdp, dhcp, dot1q, dot1x, dtp, hsrp, isl, mpls, stp, vtp.

Try 'yersinia protocol -h' to see protocol_options help

Please, see the man page for a full list of options and many examples.
Send your bugs & suggestions to the Yersinia developers <yersinia@yersinia.net>

^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^X^X^Z^Z^X^H^G^K, (not exit, Ctrl^C not working)
```

This is because `parser_initial()` returned 0  even after displaying help, instead of exiting cleanly.

```c
parser.c:204:12 : return non <0 here
    return 0;
    ~~~~~~~^
 
yersinia.c:201:55: will clean_exit when parser_initial return < 0
   if (parser_initial(tty_tmp, cl_args, argc, argv) < 0) {
                                              ~~~~~~~~^
      clean_exit();
      ~~~~ ^ ~~~~

```

### ✅ Solution

Return `-1` from `parser_initial()` when help is invoked to signal `main()` to terminate early via `clean_exit()`.

### 🔧 Patch


```diff
diff --git a/src/parser.c b/src/parser.c
index f3912c3..ca35edc 100644
--- a/src/parser.c
+++ b/src/parser.c
@@ -103,7 +103,7 @@ parser_initial(struct term_tty *tty, struct cl_args *cl_args, int argc, char **a
        if (!strcmp(argv[i],"-h") || !strcmp(argv[i],"--help"))
        {
           parser_help();
-          break;
+          return -1;
        }
        else
        if (!strcmp(argv[i],"-V") || !strcmp(argv[i],"--Version"))
```

### 🧪 Tested

- ✅ `yersinia -h` prints help and exits without error.
- ✅ Normal protocol execution (e.g. `yersinia stp -attack 0 ...`) works correctly.
